### PR TITLE
Enforce equal-ish lat-lng results manually

### DIFF
--- a/app/tests/test_app.py
+++ b/app/tests/test_app.py
@@ -10,7 +10,7 @@ from urllib.parse import urlencode
 # Internal imports
 from app import app
 from app.controllers.tests.utils import ADDRESS_TO_LATLNG_DICT
-from app.models.lat_lng import LatLng
+from app.models.lat_lng import LatLng, EQUALISH_NDIGITS_PRECISION
 
 
 class TestApp(unittest.TestCase):
@@ -38,11 +38,16 @@ class TestApp(unittest.TestCase):
             }))
             resp_data = json.loads(resp.data)
 
-            # Check response.
+            # Check response; lat and lng responses must be equal-ish.
             expected_dict = {
                 LatLng.API_FIELD_LAT: lat_lng.lat,
                 LatLng.API_FIELD_LNG: lat_lng.lng,
             }
-            # TODO: Use constant-str keys.
-            self.assertTrue(resp_data == expected_dict,
-                            "Response data dict (%s) should match expected simple dict (%s)" % (resp_data, expected_dict))  # NOQA: E501
+            self.assertEqual(
+                set(resp_data.keys()),
+                set(expected_dict.keys()),
+                "Response data keys (%s) not equal to expected keys (%s)" % (resp_data.keys(), expected_dict.keys()))
+            self.assertAlmostEqual(
+                resp_data[LatLng.API_FIELD_LAT], lat_lng.lat, places=EQUALISH_NDIGITS_PRECISION)
+            self.assertAlmostEqual(
+                resp_data[LatLng.API_FIELD_LNG], lat_lng.lng, places=EQUALISH_NDIGITS_PRECISION)


### PR DESCRIPTION
* Manually compare dict keys and values to ensure equal-ish, instead of
  enforcing exact equality.
* Exact equality was breaking tests in an undesired way.